### PR TITLE
Process overScrollBy events while view is not being dragged

### DIFF
--- a/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.kt
+++ b/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.kt
@@ -109,7 +109,6 @@ open class NestedScrollWebView : WebView, NestedScrollingChild3 {
         coordinatorLayoutChildHelper.onViewAttached(this)
     }
 
-    // Disabled to avoid double over-scrolling.
     override fun overScrollBy(
         deltaX: Int,
         deltaY: Int,
@@ -120,8 +119,20 @@ open class NestedScrollWebView : WebView, NestedScrollingChild3 {
         maxOverScrollX: Int,
         maxOverScrollY: Int,
         isTouchEvent: Boolean
-    ): Boolean =
-        true
+    ): Boolean {
+        nestedScrollingChildHelper.dispatchOverScrollIfNotBeingDragged(
+            deltaX,
+            deltaY,
+            scrollX,
+            scrollY,
+            scrollRangeX,
+            scrollRangeY,
+            maxOverScrollX,
+            maxOverScrollY,
+            isTouchEvent
+        )
+        return true
+    }
 
     // Delegation of all NestedScrollingChild3 methods
     override fun dispatchNestedScroll(

--- a/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/helper/NestedScrollViewHelper.java
+++ b/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/helper/NestedScrollViewHelper.java
@@ -660,6 +660,37 @@ public class NestedScrollViewHelper implements NestedScrollingChild3 {
 	}
 
 	/*
+	Functions not present in original NestedScrollView implementation, but may required
+	by specific views using this helper.
+	*/
+
+	public void dispatchOverScrollIfNotBeingDragged(
+			int deltaX,
+			int deltaY,
+			int scrollX,
+			int scrollY,
+			int scrollRangeX,
+			int scrollRangeY,
+			int maxOverScrollX,
+			int maxOverScrollY,
+			boolean isTouchEvent
+	) {
+		if (!mIsBeingDragged) {
+			overScrollByCompat(
+					deltaX,
+					deltaY,
+					scrollX,
+					scrollY,
+					scrollRangeX,
+					scrollRangeY,
+					maxOverScrollX,
+					maxOverScrollY,
+					isTouchEvent
+			);
+		}
+	}
+
+	/*
 	Required NestedScrollView methods implementation dependencies. As this class
 	does not inherit from any specific View, and we want to have NestedScrollView code as
 	original as possible, we provide required functions below.


### PR DESCRIPTION
### :tickets: Internal Jira ticket
[ANDROID-11710](https://jira.tid.es/browse/ANDROID-11710)

### :goal_net: What's the goal?
Fix an issue that was making webview scroll to be maintained when user navigates to a new page.

### :construction: How do we do it?
* Just process overScrollBy events in cases view is not being dragged, as we should not do it otherwise to avoid double overscrolling.

### :test_tube: How can I check this?
- [x] 🖼️ Screenshots/Videos

https://github.com/Telefonica/android-nested-scroll-webview/assets/5360064/ed97169b-78a9-4e5d-92a9-41eee51a0850

