### PR TITLE
ANDROID-13422 Reset scroll offset on touch down

### DIFF
--- a/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.java
+++ b/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.java
@@ -208,9 +208,9 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
 
         if (actionMasked == MotionEvent.ACTION_DOWN) {
             mNestedYOffset = 0;
-            /* Not present on NestedScrollView code. We need to reset scroll offset,
-            as we found that on some cases down action was invoked with non 0 scroll offset
-            while testing, breaking page scroll. */
+            /* Not present on NestedScrollView code. We need to reset scroll offset on touch down,
+            as we found while testing that in some cases action was invoked with a non-zero scroll
+            offset, breaking page scroll. */
             mScrollOffset[1] = 0;
         }
 

--- a/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.java
+++ b/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.java
@@ -208,6 +208,10 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
 
         if (actionMasked == MotionEvent.ACTION_DOWN) {
             mNestedYOffset = 0;
+            /* Not present on NestedScrollView code. We need to reset scroll offset,
+            as we found that on some cases down action was invoked with non 0 scroll offset
+            while testing, breaking page scroll. */
+            mScrollOffset[1] = 0;
         }
 
         MotionEvent vtev = MotionEvent.obtain(ev);


### PR DESCRIPTION
We need to reset scroll offset on touch down, as we found while testing that in some cases action was invoked with a non-zero scroll offset, breaking page scroll.