### PR TITLE
ANDROID-13965 Prevent implementation from crashing in case ACTION_POINTER_UP is received with an invalid pointer.

### DIFF
--- a/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.java
+++ b/nestedscrollwebview/src/main/java/com/telefonica/nestedscrollwebview/NestedScrollWebView.java
@@ -365,6 +365,13 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
             }
             case MotionEvent.ACTION_POINTER_UP:
                 onSecondaryPointerUp(ev);
+                /* Code not present on NestedScrollView code.
+                Prevent crash on last motion update due an invalid pointerId. */
+                if (ev.findPointerIndex(mActivePointerId) == -1) {
+                    Log.e(TAG, "Invalid pointerId=" + mActivePointerId + " in onTouchEvent for ACTION_POINTER_UP");
+                    break;
+                }
+                /* End of code not present on NestedScrollView code. */
                 mLastMotionY = (int) ev.getY(ev.findPointerIndex(mActivePointerId));
                 break;
         }


### PR DESCRIPTION
### :tickets: Jira ticket

[ANDROID-13965](https://jira.tid.es/browse/ANDROID-13965)

### :goal_net: What's the goal?

In case it's not possible to retrieve active pointer index from the received event, ignore it as it would crash otherwise when trying to obtain Y position.