### PR TITLE
ANDROID-16209 Migrate [android-nested-scroll-webview] from OSSRH to Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,4 +20,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
-        --max-workers 1 closeAndReleaseStagingRepository"
+        --max-workers 1 closeAndReleaseStagingRepositories"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -22,4 +22,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}"
+        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
+        --max-workers 1 closeAndReleaseStagingRepository"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -23,4 +23,4 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DSNAPSHOT_VERSION=${{ github.event.inputs.snapshotVersion }}
-        --max-workers 1 closeAndReleaseStagingRepository"
+        --max-workers 1 closeAndReleaseStagingRepositories"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'com.android.application' version '7.4.2' apply false
     id 'com.android.library' version '7.4.2' apply false
     id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
-    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0' apply false
     id 'io.gitlab.arturbosch.detekt' version '1.22.0'
 }
 

--- a/publish_maven_central.gradle
+++ b/publish_maven_central.gradle
@@ -6,6 +6,8 @@ nexusPublishing {
             stagingProfileId = "f7fe7699e57a"
             username = System.getenv("MOBILE_MAVENCENTRAL_USER")
             password = System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-16209](https://jira.tid.es/browse/ANDROID-16209)

### :goal_net: What's the goal?
Migrate Sonatype publishing to Central Portal following the [migration guide](https://confluence.tid.es/pages/viewpage.action?spaceKey=CTO&title=Migration+from+OSSRH+to+Central+Portal#Updating+Open+Source+Projects).

### :construction: How do we do it?
* Update the Gradle Nexus Publish Plugin to version 2.0.0, which supports Central Portal.
* Add the new nexus URLs and snapshot repository URLs under the sonatype block.
* Replace closeAndReleaseStagingRepository with closeAndReleaseStagingRepositories, as this is required by the new plugin version for compatibility with Central Portal.

### :blue_book: Documentation changes?
https://confluence.tid.es/pages/viewpage.action?spaceKey=CTO&title=Migration+from+OSSRH+to+Central+Portal#Updating+Open+Source+Projects

### :test_tube: How can I test this?
